### PR TITLE
fix: Integrate FastAPI with Django in ASGI configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/config/asgi.py
+++ b/{{cookiecutter.project_slug}}/config/asgi.py
@@ -28,5 +28,21 @@ application = ProtocolTypeRouter({
     # ),
 })
 {% else %}
-application = get_asgi_application()
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+django_app = get_asgi_application()
+from django.conf import settings
+from app.api.main import app as fastapi_app
+
+main_app = FastAPI()
+main_app.mount(
+    "/static",
+    StaticFiles(directory=str(settings.BASE_DIR / "app" / "static")),
+    name="static",
+)
+main_app.mount("/api", fastapi_app)
+main_app.mount("/", django_app)
+
+application = main_app
 {% endif %}


### PR DESCRIPTION
- Update asgi.py to mount FastAPI alongside Django, allowing for a unified application.
- Configure static file serving and API routing within the FastAPI instance.
- This integration enhances the project's capability to handle both FastAPI and Django requests seamlessly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved application architecture to support both FastAPI and Django features within the same deployment.
  * Static files are now served directly at the `/static` endpoint.
  * API endpoints are accessible under the `/api` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->