### PR TITLE
Raise the Python floor to 3.13 and align every target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: ^{{cookiecutter.project_slug}}/app/db/migrations/
 default_language_version:
-  python: python3.12
+  python: python3.13
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A modern, well-structured Django project template that helps you quickly set up 
 
 ## Prerequisites
 
-- Python 3.12 or higher
+- Python 3.13 or higher
 - [Cookiecutter](https://cookiecutter.readthedocs.io/) (`pip install cookiecutter`)
 - [uv](https://docs.astral.sh/uv/) for dependency management
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose (optional, for the containerized dev setup)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ norecursedirs = [
 # ==== Ruff ====
 [tool.ruff]
 line-length = 79
-target-version = "py312"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "C90", "I", "N", "UP", "B", "SIM"]

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim AS base
+FROM python:3.13-slim AS base
 
 # Install uv (see https://docs.astral.sh/uv/guide/integration/docker/)
 COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /uvx /usr/local/bin/

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     # Core Django & dependencies
     "Django==5.2.16",
@@ -145,8 +145,8 @@ exclude = [
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.12
-target-version = "py312"
+# Assume Python 3.13
+target-version = "py313"
 
 [tool.ruff.lint]
 # https://docs.astral.sh/ruff/rules/
@@ -254,7 +254,7 @@ force-single-line = true
 
 # ==== mypy ====
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 check_untyped_defs = true
 ignore_missing_imports = true
 strict = true


### PR DESCRIPTION
## What

Raises the minimum Python from 3.12 to 3.13 and moves every declaration that has to agree with it in lockstep:

| Setting | Before | After |
| --- | --- | --- |
| `requires-python` (generated project) | `>=3.12` | `>=3.13` |
| ruff `target-version` (root + template) | `py312` | `py313` |
| mypy `python_version` | `3.12` | `3.13` |
| Dockerfile base image | `python:3.12-slim` | `python:3.13-slim` |
| pre-commit `default_language_version` | `python3.12` | `python3.13` |
| README prerequisite | Python 3.12+ | Python 3.13+ |

5 files, 8 lines.

## Why

These were already internally consistent on 3.12 — `requires-python`, ruff's `target-version` and mypy's `python_version` all agreed — so there was no drift to fix. The problem was the value itself: 3.12's bugfix window closed in April 2025, and it's a stale default to hand a brand new project.

Django 5.2 LTS supports 3.13 for its full support window (to April 2028), and every pinned dependency publishes 3.13 wheels, so this costs nothing in compatibility.

Bumping all six in one commit is deliberate — they're a single fact expressed in six places, and splitting them lets them drift.

## Verification

Baked all four flag combinations the CI matrix covers (default, `use_fastapi=y`, `use_channels=y`, `use_sentry=y`) and ran the full gate set against each: `ruff check`, `ruff format --check`, `djlint --check`, `makemigrations --check --dry-run`, `pytest`. All pass.

One risk worth naming since it's non-obvious: Python 3.13 removed the stdlib `crypt` module, which `passlib` (still present in the FastAPI option at this commit) touches in some backends. Verified explicitly that the `use_fastapi=y` combo still installs and passes its 12 tests on 3.13 — the bcrypt backend is used, not the `crypt` one. This PR does not depend on anything else and is safe to merge on its own.

## Notes

`{{cookiecutter.project_slug}}/.python-version` also says `3.13` locally, but it's matched by `.gitignore:62` and has never been tracked, so it isn't in this diff. `requires-python` is what actually selects the interpreter. Pre-existing; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)