### PR TITLE
Pin setup-uv to a tag that exists (CI is currently broken on main)

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
## The problem

Every CI job on `main` fails ~3 seconds in, during **Set up job**, before checkout even runs:

```
Unable to resolve action `astral-sh/setup-uv@v9`, unable to find version `v9`
```

`astral-sh/setup-uv` published a `v9.0.0` release but **never created a moving `v9` major tag**. Its newest major tag is `v7`:

```
v9        -> 404 Not Found
v8        -> 404 Not Found
v9.0.0    -> c771a70   ✅
v7        -> 94527f2   ✅
```

## Blast radius

This isn't only this repo's CI. The same broken ref is in the **generated project's** `.github/workflows/ci.yml`, in all four jobs — so every project baked from this template has shipped with a pipeline that can never start.

| File | Occurrences |
| --- | --- |
| `.github/workflows/validate-template.yml` | 2 |
| `{{cookiecutter.project_slug}}/.github/workflows/ci.yml` | 4 |

## The fix

`astral-sh/setup-uv@v9` → `astral-sh/setup-uv@v9.0.0`, in both files. 6 lines.

Pinning the exact release rather than falling back to `@v7` keeps the intended version. The tradeoff is that patch releases no longer arrive automatically — for a CI action that's the safer side to err on.

`actions/checkout@v7` is untouched; that major tag does exist.

## Why this jumps the queue

This is pre-existing on `main`, not introduced by any of the pending work. It's going first because until it lands, every PR in the queue shows red checks for a reason that has nothing to do with its contents, which makes review meaningless. This PR is its own verification: if CI goes green here, it worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)