### PR TITLE
Point generated settings comments at the Django 5.2 docs

### DIFF
--- a/{{cookiecutter.project_slug}}/config/asgi.py
+++ b/{{cookiecutter.project_slug}}/config/asgi.py
@@ -4,7 +4,7 @@ ASGI config for {{ cookiecutter.project_name }} project.
 It exposes the ASGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
+https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 """
 
 import os

--- a/{{cookiecutter.project_slug}}/config/base.py
+++ b/{{cookiecutter.project_slug}}/config/base.py
@@ -17,7 +17,7 @@ env = environ.Env()
 environ.Env.read_env(BASE_DIR / ".env")
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # Raises Django's ImproperlyConfigured
 # exception if SECRET_KEY not in os.environ
@@ -105,11 +105,11 @@ WSGI_APPLICATION = "config.wsgi.application"
 
 
 # Database
-# https://docs.djangoproject.com/en/5.0/ref/settings/#databases
+# https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 DATABASES = {"default": env.db()}
 
 # Password validation
-# https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators
+# https://docs.djangoproject.com/en/5.2/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -128,7 +128,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/5.0/topics/i18n/
+# https://docs.djangoproject.com/en/5.2/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
 
@@ -140,7 +140,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/5.0/howto/static-files/
+# https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
@@ -154,12 +154,12 @@ VITE_DEV_SERVER_URL = "http://localhost:5173"
 VITE_MANIFEST_PATH = "app/static/dist/.vite/manifest.json"
 
 # Default primary key field type
-# https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
+# https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # User model
-# https://docs.djangoproject.com/en/5.0/ref/settings/#auth-user-model
+# https://docs.djangoproject.com/en/5.2/ref/settings/#auth-user-model
 AUTH_USER_MODEL = "app.User"
 
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True

--- a/{{cookiecutter.project_slug}}/config/urls.py
+++ b/{{cookiecutter.project_slug}}/config/urls.py
@@ -2,7 +2,7 @@
 URL configuration for {{ cookiecutter.project_name }} project.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.0/topics/http/urls/
+    https://docs.djangoproject.com/en/5.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/{{cookiecutter.project_slug}}/config/wsgi.py
+++ b/{{cookiecutter.project_slug}}/config/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for {{ cookiecutter.project_name }} project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 """
 
 import os


### PR DESCRIPTION
## What

Retargets ten documentation links in the generated project's `config/` comments from `/en/5.0/` to `/en/5.2/`.

**Comments only** — 4 files, 10 lines, zero behaviour change. Every changed line contains `docs.djangoproject.com`; I checked (20 `+`/`-` lines, 0 of them non-URL).

| File | Links |
| --- | --- |
| `config/base.py` | 7 |
| `config/asgi.py` | 1 |
| `config/urls.py` | 1 |
| `config/wsgi.py` | 1 |

## Why

The template pins Django 5.2 LTS, but these comments still pointed at the 5.0 docs. Those pages still resolve, so nothing is broken — but a developer following a link from a freshly generated project lands on documentation for a release that hit end of life in April 2025, one and a half versions behind the code they're reading. That's the kind of small wrongness that quietly teaches people to distrust the comments.

A few links deliberately left alone: `config/base.py` has two `/en/dev/` links (for `DEBUG` and `ALLOWED_HOSTS`) which intentionally track the development docs rather than a pinned version. Retargeting those would be a different decision, so they're untouched.

## Verification

Comment-only, but ran the gates anyway rather than assume. Baked all flag combinations and ran `ruff check`, `ruff format --check`, `djlint --check`, `makemigrations --check --dry-run` and `pytest` against each — all pass.

Branch is cut from current `main` (`8171b20`), so CI runs clean against the fixed `setup-uv` pin with no rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)