### PR TITLE
Keep "$" out of the generated SECRET_KEY

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -42,8 +42,13 @@ def remove_celery_files():
 
 
 def generate_secret_key():
-    """Generate a random Django secret key."""
-    chars = string.ascii_letters + string.digits + "!@#$%^&*(-_=+)"
+    """Generate a random Django secret key.
+
+    Deliberately excludes "$": this key is written to .env, and Docker
+    Compose interpolates $NAME in that file, so a key containing one would
+    silently reach the containers with part of it stripped out.
+    """
+    chars = string.ascii_letters + string.digits + "!@#%^&*(-_=+)"
     return "".join(random.choice(chars) for _ in range(50))
 
 


### PR DESCRIPTION
## The bug

`post_gen_project.py` writes the generated key into `.env`, and Docker Compose expands `$NAME` references when it reads that file. A key containing a `$` therefore reaches the containers with everything from the `$` to the next delimiter silently deleted.

This is how it surfaced — `docker compose config` on a freshly generated project:

```
level=warning msg="The \"PdGW7eB\" variable is not set. Defaulting to a blank string."
```

Django gets a different, shorter key than the one sitting on disk. No error, no crash.

## It was not an edge case

The old alphabet was 76 characters including `$`, over 50 positions:

| | keys containing `$`, out of 10,000 |
| --- | --- |
| old alphabet | **4,931 (49%)** |
| new alphabet | 0 |

**Roughly half of all generated projects were affected.**

## Why it matters

Sessions issued inside Docker didn't survive a switch to running locally, and vice versa, for no visible reason — the two environments were using different signing keys despite reading the same `.env`.

It matters more now that the API signs bearer tokens with `SECRET_KEY`: the same mismatch silently invalidates every outstanding token across that boundary, which looks like random auth failures rather than a config problem.

## The fix

Drop `$` from the alphabet. One character out of 76.

| | alphabet | entropy over 50 chars |
| --- | --- | --- |
| before | 76 | 312 bits |
| after | 75 | **311 bits** |

One bit. Nothing this key protects notices the difference.

The reasoning is recorded in the docstring so nobody helpfully adds `$` back.

## Verification

Baked a project and confirmed end to end:

- generated `SECRET_KEY`: 50 chars, **no `$`**
- `docker compose config`: **0 interpolation warnings** (this is the check that originally exposed the bug)
- `ruff check`, `ruff format --check`, `djlint --check`, `makemigrations --check --dry-run`, `pytest` — all pass

Branch cut from current `main` (`a37b6cf`).

## Note

This is the last of the six items from the original review. Everything else is already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)