### PR TITLE
DO NOT MERGE: verify the mypy gate fails CI

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -66,6 +66,16 @@ jobs:
         working-directory: testproj
         run: uv run djlint . --check
 
+      # The generated project's own ci.yml runs mypy as a blocking job, so
+      # it has to be checked here too - otherwise a template change that
+      # breaks type checking passes this workflow and only surfaces on the
+      # first CI run of somebody's newly generated project. Run per flag
+      # combination, because which files exist (and even what a list's
+      # element type infers to) depends on the flags.
+      - name: mypy
+        working-directory: testproj
+        run: uv run mypy .
+
       - name: Check for missing migrations
         working-directory: testproj
         run: uv run python manage.py makemigrations --check --dry-run

--- a/{{cookiecutter.project_slug}}/app/models/permission.py
+++ b/{{cookiecutter.project_slug}}/app/models/permission.py
@@ -6,4 +6,4 @@ class Permission(models.Model):
     name = models.CharField(max_length=255)
 
     def __str__(self) -> str:
-        return 12345  # DELIBERATE TYPE ERROR - verification only
+        return self.name

--- a/{{cookiecutter.project_slug}}/app/models/permission.py
+++ b/{{cookiecutter.project_slug}}/app/models/permission.py
@@ -6,4 +6,4 @@ class Permission(models.Model):
     name = models.CharField(max_length=255)
 
     def __str__(self) -> str:
-        return self.name
+        return 12345  # DELIBERATE TYPE ERROR - verification only

--- a/{{cookiecutter.project_slug}}/config/custom_template_tag_loader.py
+++ b/{{cookiecutter.project_slug}}/config/custom_template_tag_loader.py
@@ -28,7 +28,7 @@ def get_custom_template_tag_modules(
                 yield module_name, name
 
 
-def get_custom_template_tags(folders: Iterable[str]) -> dict[str, str]:
+def get_custom_template_tags(folders: Iterable[str]) -> list[str]:  # DELIBERATE
     """
     Return a dictionary mapping custom template tag module names
     to their full import paths.


### PR DESCRIPTION
Temporary PR to prove the new mypy step in `validate-template.yml` actually fails the workflow. Contains a deliberate type error in `app/models/permission.py`. Will be closed and the branch deleted once the checks report.